### PR TITLE
Actin membrane brownian ratchet

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ See [examples/README.md](examples/README.md) to run example actin, microtubules,
 
 1. Create a virtual environment with conda-specific dependencies: `conda env create -f environment.yml`
 2. Activate the environment: `conda activate readdy_models`
+3. Install just command runner: `conda install -c conda-forge just`
 3. Install remaining dependencies: `just install`
 
 ## Development

--- a/examples/actin-parameters.md
+++ b/examples/actin-parameters.md
@@ -1,0 +1,526 @@
+# Parameters in actin model
+
+## "name"
+default value: "actin"
+
+units: NA
+
+Output file name.
+
+## "total_steps"
+default value: 1e3
+
+units: count
+
+Total number of steps to run in ReaDDy.
+
+## "time_step"
+default value: 0.0000001
+
+units: s
+
+Time step for Vivarium process.
+
+## "internal_timestep"
+default value: 0.1
+
+units: ns
+
+Time that passes in one ReaDDy timestep.
+
+## "box_size"
+default value: [500.0, 500.0, 500.0]
+
+units: nm
+
+Dimensions of the simulation box in nanometers. If one value is given (e.g. 500.0) that value will be used for all three dimensions.
+
+## "periodic_boundary"
+default value: True
+
+units: NA
+
+Use a periodic boundary at the edges of the simulation box? If True, particles will reflect to the other side of the box when they cross the boundary. If False, particles will be constrained to the edges of the box with a box potential.
+
+## "reaction_distance"
+default value: 1.0
+
+units: nm
+
+Extra distance between particles where a reaction can be triggered. Larger values increase reaction events at the expense of spatial accuracy.
+
+## "n_cpu"
+default value: 4
+
+units: count
+
+How many CPU cores to use?
+
+## "actin_concentration"
+default value: 200.0
+
+units: uM
+
+Concentration of free actin monomers to add in the initial conditions.
+
+## "arp23_concentration"
+default value: 10.0
+
+units: uM
+
+Concentration of free Arp23 monomers to add in the initial conditions.
+
+## "cap_concentration"
+default value: 0.0
+
+units: uM
+
+Concentration of free capping protein molecules to add in the initial conditions.
+
+## "seed_n_fibers"
+default value: 0
+
+units: count
+
+How many randomly oriented linear actin fibers to seed the simulation with in the initial conditions?
+
+## "seed_fiber_length"
+default value: 0.0
+
+units: nm
+
+Length of random linear actin seed fibers.
+
+## "orthogonal_seed"
+default value: False
+
+units: NA
+
+Add a seed actin fiber along the x-axis?
+
+## "orthogonal_seed_length"
+default value: 50.0
+
+units: nm
+
+Length of seed actin fiber along x-axis.
+
+## "branched_seed"
+default value: False
+
+units: NA
+
+Add a branched actin molecule in the initial conditions?
+
+## "only_linear_actin_constraints"
+default value: False
+
+units: NA
+
+If true, only add constraints for linear actin, skip adding branch constraints. Skipping these can speed up simulation initialization and calculation if branching is not used.
+
+## "reactions"
+default value: True
+
+units: NA
+
+Evaluate reactions? If false, no reactions will occur. This can speed up simulation calculation if reactions are not needed.
+
+## "dimerize_rate"
+default value: 2.1e-2
+
+units: 1/ns
+
+Rate of dimerization reaction between two free actin monomers. Turning this off (using a very small rate like 1e-30) can prevent actin monomers from being used up in dimerization reactions, which would normally be regulated by other molecules in vivo.
+
+## "dimerize_reverse_rate"
+default value: 1.4e-9
+
+units: 1/ns
+
+Rate of decay of a fiber of length 2 monomers. 
+
+## "trimerize_rate"
+default value: 2.1e-2
+
+units: 1/ns
+
+Rate of trimerization reaction between a free actin monomer and a fiber of length 2 monomers. 
+
+## "trimerize_reverse_rate"
+default value: 1.4e-9
+
+units: 1/ns
+
+Rate of decay of a fiber of length 3 monomers. 
+
+## "pointed_growth_ATP_rate"
+default value: 2.4e-5
+
+units: 1/ns
+
+Rate of growth of the pointed end of actin fibers of any ATP state reacting with an ATP-actin monomer.
+
+## "pointed_growth_ADP_rate"
+default value: 2.95e-6
+
+units: 1/ns
+
+Rate of growth of the pointed end of actin fibers of any ATP state reacting with an ADP-actin monomer.
+
+## "pointed_shrink_ATP_rate"
+default value: 8.0e-10
+
+units: 1/ns
+
+Rate of loss of a monomer from the pointed end of actin fibers where the pointed end monomer is bound with ATP.
+
+## "pointed_shrink_ADP_rate"
+default value: 3.0e-10
+
+units: 1/ns
+
+Rate of loss of a monomer from the pointed end of actin fibers where the pointed end monomer is bound with ADP.
+
+## "barbed_growth_ATP_rate"
+default value: 2.1e-2
+
+units: 1/ns
+
+Rate of growth of the barbed end of actin fibers of any ATP state reacting with an ATP-actin monomer.
+
+## "barbed_growth_ADP_rate"
+default value: 7.0e-5
+
+units: 1/ns
+
+Rate of growth of the barbed end of actin fibers of any ATP state reacting with an ADP-actin monomer.
+
+## "nucleate_ATP_rate"
+default value: 2.1e-2
+
+units: 1/ns
+
+Rate of nucleation (formation of a 4-monomer fiber) reacting with an ATP-actin monomer.
+
+## "nucleate_ADP_rate"
+default value: 7.0e-5
+
+units: 1/ns
+
+Rate of nucleation (formation of a 4-monomer fiber) reacting with an ADP-actin monomer.
+
+## "barbed_shrink_ATP_rate"
+default value: 1.4e-9
+
+units: 1/ns
+
+Rate of loss of a monomer from the barbed end of actin fibers where the barbed end monomer is bound with ATP.
+
+## "barbed_shrink_ADP_rate"
+default value: 8.0e-9
+
+units: 1/ns
+
+Rate of loss of a monomer from the barbed end of actin fibers where the barbed end monomer is bound with ADP.
+
+## "arp_bind_ATP_rate"
+default value: 2.1e-2
+
+units: 1/ns
+
+Rate of binding of an Arp23 dimer to an ATP-actin monomer in an actin fiber.
+
+## "arp_bind_ADP_rate"
+default value: 7.0e-5
+
+units: 1/ns
+
+Rate of binding of an Arp23 dimer to an ADP-actin monomer in an actin fiber.
+
+## "arp_unbind_ATP_rate"
+default value: 1.4e-9
+
+units: 1/ns
+
+Rate of dissociation of an ATP-Arp23 dimer from an actin fiber.
+
+## "arp_unbind_ADP_rate"
+default value: 8.0e-9
+
+units: 1/ns
+
+Rate of dissociation of an ADP-Arp23 dimer from an actin fiber.
+
+## "barbed_growth_branch_ATP_rate"
+default value: 2.1e-2
+
+units: 1/ns
+
+Rate of binding of an ATP-actin monomer to an Arp23 bound on an actin fiber.
+
+## "barbed_growth_branch_ADP_rate"
+default value: 7.0e-5
+
+units: 1/ns
+
+Rate of binding of an ADP-actin monomer to an Arp23 bound on an actin fiber.
+
+## "debranching_ATP_rate"
+default value: 1.4e-9
+
+units: 1/ns
+
+Rate of dissociation of an actin monomer from an ATP-Arp23 bound on an actin fiber.
+
+## "debranching_ADP_rate"
+default value: 7.0e-5
+
+units: 1/ns
+
+Rate of dissociation of an actin monomer from an ADP-Arp23 bound on an actin fiber.
+
+## "cap_bind_rate"
+default value: 2.1e-2
+
+units: 1/ns
+
+Rate of binding of capping protein to the barbed end of an actin fiber.
+
+## "cap_unbind_rate"
+default value: 1.4e-9
+
+units: 1/ns
+
+Rate of dissociation of capping protein from the barbed end of an actin fiber.
+
+## "hydrolysis_actin_rate"
+default value: 3.5e-5
+
+units: 1/ns
+
+Rate of hydrolysis of ATP bound to actin monomers in a fiber.
+
+## "hydrolysis_arp_rate"
+default value: 3.5e-5
+
+units: 1/ns
+
+Rate of hydrolysis of ATP bound to Arp23 in a fiber.
+
+## "nucleotide_exchange_actin_rate"
+default value: 1e-5
+
+units: 1/ns
+
+Rate of exchange of an ADP for an ATP in a free actin monomer.
+
+## "nucleotide_exchange_arp_rate"
+default value: 1e-5
+
+units: 1/ns
+
+Rate of exchange of an ADP for an ATP in a free Arp23 monomer.
+
+## "verbose"
+default value: False
+
+units: NA
+
+Print log statements including for each reaction.
+
+## "use_box_actin"
+default value: False
+
+units: NA
+
+Confine free actin monomers to a box. Also requires parameters "actin_box_center_x", "actin_box_center_y", "actin_box_center_z", "actin_box_size_x", "actin_box_size_y", "actin_box_size_z".
+
+## "use_box_arp"
+default value: False
+
+units: NA
+
+Confine free Arp23 dimers to a box. Also requires parameters "arp_box_center_x", "arp_box_center_y", "arp_box_center_z", "arp_box_size_x", "arp_box_size_y", "arp_box_size_z".
+
+## "use_box_cap"
+default value: False
+
+units: NA
+
+Confine free capping protein to a box. Also requires parameters "cap_box_center_x", "cap_box_center_y", "cap_box_center_z", "cap_box_size_x", "cap_box_size_y", "cap_box_size_z".
+
+## "add_obstacles"
+default value: False
+
+units: NA
+
+Add obstacle particles, which take up space but don't react?
+
+## "obstacle_radius"
+default value: 35.0
+
+units: nm
+
+Radius of obstacle particles, which take up space but don't react.
+
+## "obstacle_diff_coeff"
+default value: 0.0
+
+units: nm^2/s
+
+Diffusion coefficient of obstacle particles, which take up space but don't react.
+
+## "use_box_obstacle"
+default value: False
+
+units: NA
+
+Confine obstacle particles to a box. Also requires parameters "obstacle_box_center_x", "obstacle_box_center_y", "obstacle_box_center_z", "obstacle_box_size_x", "obstacle_box_size_y", "obstacle_box_size_z".
+
+## "position_obstacle_stride"
+default value: 0
+
+units: count
+
+Number of frames between each time the obstacle position is set to the controlled position. Also requires parameters "obstacle_controlled_position_x", "obstacle_controlled_position_y", "obstacle_controlled_position_z"
+
+## "n_fixed_monomers_pointed"
+default value: 0
+
+units: count
+
+Number of monomers at the pointed end of the orthogonal seed fiber to freeze in space.
+
+## "n_fixed_monomers_barbed"
+default value: 0
+
+units: count
+
+Number of monomers at the barbed end of the orthogonal seed fiber to freeze in space.
+
+## "displace_pointed_end_tangent"
+default value: False
+
+units: NA
+
+Displace the pointed end of the orthogonal seed fiber along the positive X-axis? Also requires parameter "tangent_displacement_nm", "displace_stride".
+
+## "displace_pointed_end_radial"
+default value: False
+
+units: NA
+
+Displace the pointed end of the orthogonal seed fiber in an arc with a given radius? Also requires parameters "radial_displacement_radius_nm", "radial_displacement_angle_deg", "displace_stride".
+
+## "plot_polymerization"
+default value: False
+
+units: NA
+
+Plot polymerization rate data in Simularium file?
+
+## "plot_filament_structure"
+default value: False
+
+units: NA
+
+Plot filament structure (angles, lengths, etc) data in Simularium file?
+
+## "plot_bend_twist"
+default value: False
+
+units: NA
+
+Plot actin fiber bend and twist data in Simularium file?
+
+## "plot_actin_compression"
+default value: False
+
+units: NA
+
+Plot actin fiber compression data in Simularium file?
+
+## "visualize_edges"
+default value: False
+
+units: NA
+
+Visualize lines for each bond edge in the Simularium file?
+
+## "visualize_normals"
+default value: False
+
+units: NA
+
+Visualize lines for each bound actin monomer's normal in the Simularium file?
+
+## "visualize_control_pts"
+default value: False
+
+units: NA
+
+Visualize points for each actin monomer's nearest position on the fiber backbone in the Simularium file?
+
+## "longitudinal_bonds"
+default value: True
+
+units: NA
+
+Create bonds between every other consecutive actin monomer in a fiber?
+
+## "bonds_force_multiplier"
+default value: 0.2
+
+units: None
+
+Multiplier to use for force constants enforcing bonds.
+
+## "angles_force_constant"
+default value: 1000.0
+
+units: None
+
+Multiplier to use for force constants enforcing angle constraints.
+
+## "dihedrals_force_constant"
+default value: 1000.0
+
+units: None
+
+Multiplier to use for force constants enforcing cosine dihedral constraints.
+
+## "add_membrane"
+default value: False
+
+units: NA
+
+Add a coarse grained particle membrane?
+
+## "actin_constraints"
+default value: True
+
+units: NA
+
+Enforce angle and dihedral constraintes to maintain actin fiber structure? If false, computation will be faster but structure will be inaccurate.
+
+## "add_extra_box"
+default value: False
+
+units: NA
+
+Add an extra box potential as an obstacle for actin, which could represent a membrane or another obstacle without explicitly representing it with particles. Also requires parameters "extra_box_center_x", "extra_box_center_y", "extra_box_center_z", "extra_box_size_x", "extra_box_size_y", "extra_box_size_z".
+
+## "barbed_binding_site"
+default value: False
+
+units: NA
+
+Add an explicit particle for a binding site for actin at the barbed end of actin filaments? If true, will increase accuracy of binding for actin monomers.
+
+## "binding_site_reaction_distance"
+default value: 0.1
+
+units: nm
+
+Distance between binding site particles and actin monomers to trigger a reaction. Larger values increase reaction events at the expense of spatial accuracy.

--- a/simularium_readdy_models/actin/actin_generator.py
+++ b/simularium_readdy_models/actin/actin_generator.py
@@ -552,12 +552,12 @@ class ActinGenerator:
             actin_arp_ids = None
         if barbed_binding_site and len(particle_ids) > 1:
             particles = ActinGenerator._set_particle_type_name(
-                "actin#barbed_ATP_" ,
+                "actin#barbed_ATP_",
                 particle_ids[len(particle_ids) - 2],
                 particles,
             )
         particles = ActinGenerator._set_particle_type_name(
-            "actin#barbed_ATP_" if not barbed_binding_site else "binding_site#" ,
+            "actin#barbed_ATP_" if not barbed_binding_site else "binding_site#",
             particle_ids[len(particle_ids) - 1],
             particles,
         )
@@ -886,13 +886,17 @@ class ActinGenerator:
         return monomers
 
     @staticmethod
-    def get_free_actin_monomers(concentration, box_center, box_size, start_particle_id, start_top_id):
+    def get_free_actin_monomers(
+        concentration, box_center, box_size, start_particle_id, start_top_id
+    ):
         result = {
             "topologies": {},
             "particles": {},
         }
         n_particles = ReaddyUtil.calculate_nParticles(concentration, box_size)
-        positions = box_center + (np.random.uniform(size=(n_particles, 3)) - 0.5) * box_size
+        positions = (
+            box_center + (np.random.uniform(size=(n_particles, 3)) - 0.5) * box_size
+        )
         p_id = start_particle_id
         top_id = start_top_id
         for p in range(len(positions)):
@@ -904,7 +908,7 @@ class ActinGenerator:
                 "unique_id": p_id,
                 "type_name": "actin#free_ATP",
                 "position": positions[p],
-                "neighbor_ids": []
+                "neighbor_ids": [],
             }
             p_id += 1
             top_id += 1

--- a/simularium_readdy_models/actin/actin_generator.py
+++ b/simularium_readdy_models/actin/actin_generator.py
@@ -859,21 +859,23 @@ class ActinGenerator:
         return result
 
     @staticmethod
-    def setup_fixed_monomers(monomers, parameters):
+    def setup_fixed_monomers(
+        monomers, orthogonal_seed, n_fixed_monomers_pointed, n_fixed_monomers_barbed
+    ):
         """
         Fix monomers at either end of the orthogonal actin seed.
         """
-        if not parameters["orthogonal_seed"]:
+        if not orthogonal_seed:
             return monomers
         top_id = list(monomers["topologies"].keys())[0]
         n_monomers = len(monomers["topologies"][top_id]["particle_ids"])
-        for monomer_index in range(int(parameters["n_fixed_monomers_pointed"])):
+        for monomer_index in range(n_fixed_monomers_pointed):
             type_name = monomers["particles"][monomer_index]["type_name"]
             type_name = ReaddyUtil.particle_type_with_flags(
                 type_name, ["fixed"], [], reverse_sort=True
             )
             monomers["particles"][monomer_index]["type_name"] = type_name
-        for i in range(int(parameters["n_fixed_monomers_barbed"])):
+        for i in range(n_fixed_monomers_barbed):
             monomer_index = n_monomers - 1 - i
             type_name = monomers["particles"][monomer_index]["type_name"]
             type_name = ReaddyUtil.particle_type_with_flags(

--- a/simularium_readdy_models/actin/actin_generator.py
+++ b/simularium_readdy_models/actin/actin_generator.py
@@ -810,6 +810,7 @@ class ActinGenerator:
         start_normal=None,
         longitudinal_bonds=True,
         barbed_binding_site=False,
+        top_id=0,
     ):
         """
         get all the monomer data for the (branched) fibers in fibers_data.
@@ -848,7 +849,7 @@ class ActinGenerator:
                 longitudinal_bonds=longitudinal_bonds,
                 barbed_binding_site=barbed_binding_site,
             )
-            result["topologies"][ActinGenerator._get_next_monomer_id()] = {
+            result["topologies"][top_id] = {
                 "type_name": "Actin-Polymer",
                 "particle_ids": particle_ids,
             }

--- a/simularium_readdy_models/actin/actin_generator.py
+++ b/simularium_readdy_models/actin/actin_generator.py
@@ -886,6 +886,31 @@ class ActinGenerator:
         return monomers
 
     @staticmethod
+    def get_free_actin_monomers(concentration, box_center, box_size, start_particle_id, start_top_id):
+        result = {
+            "topologies": {},
+            "particles": {},
+        }
+        n_particles = ReaddyUtil.calculate_nParticles(concentration, box_size)
+        positions = box_center + (np.random.uniform(size=(n_particles, 3)) - 0.5) * box_size
+        p_id = start_particle_id
+        top_id = start_top_id
+        for p in range(len(positions)):
+            result["topologies"][top_id] = {
+                "type_name": "Actin-Monomer-ATP",
+                "particle_ids": [p_id],
+            }
+            result["particles"][p_id] = {
+                "unique_id": p_id,
+                "type_name": "actin#free_ATP",
+                "position": positions[p],
+                "neighbor_ids": []
+            }
+            p_id += 1
+            top_id += 1
+        return result
+
+    @staticmethod
     def particles_to_string(particle_ids, particles, info=""):
         result = ""
         for particle_id in particle_ids:

--- a/simularium_readdy_models/actin/actin_simulation.py
+++ b/simularium_readdy_models/actin/actin_simulation.py
@@ -21,6 +21,7 @@ class ActinSimulation:
         parameters,
         record=False,
         save_checkpoints=False,
+        readdy_system=None,
     ):
         """
         Creates a ReaDDy branched actin simulation.
@@ -49,7 +50,7 @@ class ActinSimulation:
         self.actin_util = ActinUtil(
             self.parameters, self.get_pointed_end_displacements()
         )
-        self.create_actin_system()
+        self.create_actin_system(readdy_system)
         self.simulation = ReaddyUtil.create_readdy_simulation(
             self.system,
             self._parameter("n_cpu"),
@@ -80,22 +81,25 @@ class ActinSimulation:
             return ActinUtil.DEFAULT_PARAMETERS[parameter_name]
         raise Exception(f"Parameter {parameter_name} is required but was not provided.")
 
-    def create_actin_system(self):
+    def create_actin_system(self, readdy_system):
         """
         Create the ReaDDy system for actin
         including particle types, constraints, and reactions.
         """
-        self.system = readdy.ReactionDiffusionSystem(
-            box_size=self._parameter("box_size"),
-            periodic_boundary_conditions=[bool(self._parameter("periodic_boundary"))]
-            * 3,
-        )
         self.parameters["temperature_K"] = self._parameter("temperature_C") + 273.15
-        self.system.temperature = self.parameters["temperature_K"]
-        self.add_particle_types()
-        ActinUtil.check_add_global_box_potential(self.system)
-        self.add_constraints()
-        self.add_reactions()
+        if readdy_system is None:
+            self.system = readdy.ReactionDiffusionSystem(
+                box_size=self._parameter("box_size"),
+                periodic_boundary_conditions=[bool(self._parameter("periodic_boundary"))]
+                * 3,
+            )
+            self.system.temperature = self.parameters["temperature_K"]
+            self.add_particle_types()
+            ActinUtil.check_add_global_box_potential(self.system)
+            self.add_constraints()
+            self.add_reactions()
+        else:
+            self.system = readdy_system
 
     def add_particle_types(self):
         """

--- a/simularium_readdy_models/actin/actin_simulation.py
+++ b/simularium_readdy_models/actin/actin_simulation.py
@@ -8,7 +8,7 @@ from ..common import (
     ReaddyUtil, 
     add_membrane_particle_types, 
     add_membrane_constraints, 
-    init_membrane,
+    get_membrane_monomers,
     all_membrane_particle_types
 )
 from .actin_structure import ActinStructure
@@ -352,30 +352,6 @@ class ActinSimulation:
         """
         self.actin_util.add_fibers_from_data(self.simulation, fibers_data, use_uuids)
 
-    def add_monomers_from_data(self, monomer_data):
-        """
-        Add fibers and monomers specified in the monomer_data, in the form:
-        monomer_data = {
-            "topologies": {
-                [topology ID] : {
-                    "type_name": "[topology type]",
-                    "particle_ids": [],
-                },
-            },
-            "particles": {
-                [particle ID] : {
-                    "type_name": "[particle type]",
-                    "position": np.zeros(3),
-                    "neighbor_ids": [],
-                },
-            },
-        }
-        * IDs are ints.
-        """
-        self.topologies = self.actin_util.add_monomers_from_data(
-            self.simulation, monomer_data
-        )
-
     def add_obstacles(self):
         """
         Add obstacle particles.
@@ -403,20 +379,21 @@ class ActinSimulation:
         """
         if not self._parameter("add_membrane"):
             return
-        init_membrane(
+        ReaddyUtil.add_monomers_from_data(
             self.simulation,
-            np.array([
-                float(self._parameter("membrane_center_x")),
-                float(self._parameter("membrane_center_y")),
-                float(self._parameter("membrane_center_z")),
-            ]), 
-            np.array([
-                float(self._parameter("membrane_size_x")),
-                float(self._parameter("membrane_size_y")),
-                float(self._parameter("membrane_size_z")),
-            ]), 
-            self._parameter("membrane_particle_radius"),
-            self._parameter("box_size")
+            get_membrane_monomers(
+                np.array([
+                    float(self._parameter("membrane_center_x")),
+                    float(self._parameter("membrane_center_y")),
+                    float(self._parameter("membrane_center_z")),
+                ]), 
+                np.array([
+                    float(self._parameter("membrane_size_x")),
+                    float(self._parameter("membrane_size_y")),
+                    float(self._parameter("membrane_size_z")),
+                ]), 
+                self._parameter("membrane_particle_radius"),
+            )
         )
 
     def add_crystal_structure_monomers(self):
@@ -474,7 +451,7 @@ class ActinSimulation:
                 "position": np.array(positions[index]),
                 "neighbor_ids": neighbor_ids[index],
             }
-        self.add_monomers_from_data(monomer_data)
+        ReaddyUtil.add_monomers_from_data(self.simulation, monomer_data)
 
     def simulate(self, d_time):
         """

--- a/simularium_readdy_models/actin/actin_simulation.py
+++ b/simularium_readdy_models/actin/actin_simulation.py
@@ -5,11 +5,11 @@ import numpy as np
 import readdy
 
 from ..common import (
-    ReaddyUtil, 
-    add_membrane_particle_types, 
-    add_membrane_constraints, 
+    ReaddyUtil,
+    add_membrane_particle_types,
+    add_membrane_constraints,
     get_membrane_monomers,
-    all_membrane_particle_types
+    all_membrane_particle_types,
 )
 from .actin_structure import ActinStructure
 from .actin_util import ActinUtil
@@ -90,7 +90,9 @@ class ActinSimulation:
         if readdy_system is None:
             self.system = readdy.ReactionDiffusionSystem(
                 box_size=self._parameter("box_size"),
-                periodic_boundary_conditions=[bool(self._parameter("periodic_boundary"))]
+                periodic_boundary_conditions=[
+                    bool(self._parameter("periodic_boundary"))
+                ]
                 * 3,
             )
             self.system.temperature = self.parameters["temperature_K"]
@@ -121,10 +123,15 @@ class ActinSimulation:
         self.actin_util.add_arp23_types(self.system, arp23_diffCoeff)
         self.actin_util.add_cap_types(self.system, cap_diffCoeff)
         self.system.topologies.add_type("Obstacle")
-        self.system.add_topology_species("obstacle", self._parameter("obstacle_diff_coeff"))
+        self.system.add_topology_species(
+            "obstacle", self._parameter("obstacle_diff_coeff")
+        )
         if self._parameter("add_membrane"):
             add_membrane_particle_types(
-                self.system, self._parameter("membrane_particle_radius"), temperature, viscosity
+                self.system,
+                self._parameter("membrane_particle_radius"),
+                temperature,
+                viscosity,
             )
         if self._parameter("barbed_binding_site"):
             self.actin_util.add_binding_site_types(self.system, actin_diffCoeff)
@@ -194,7 +201,7 @@ class ActinSimulation:
             self._parameter("obstacle_radius"),
             ActinUtil.DEFAULT_FORCE_CONSTANT,
             self.system,
-            util
+            util,
         )
         # box potentials
         self.actin_util.add_monomer_box_potentials(self.system)
@@ -203,26 +210,30 @@ class ActinSimulation:
         # membrane
         if self._parameter("add_membrane"):
             add_membrane_constraints(
-                self.system, 
-                np.array([
-                    float(self._parameter("membrane_center_x")),
-                    float(self._parameter("membrane_center_y")),
-                    float(self._parameter("membrane_center_z")),
-                ]), 
-                np.array([
-                    float(self._parameter("membrane_size_x")),
-                    float(self._parameter("membrane_size_y")),
-                    float(self._parameter("membrane_size_z")),
-                ]), 
+                self.system,
+                np.array(
+                    [
+                        float(self._parameter("membrane_center_x")),
+                        float(self._parameter("membrane_center_y")),
+                        float(self._parameter("membrane_center_z")),
+                    ]
+                ),
+                np.array(
+                    [
+                        float(self._parameter("membrane_size_x")),
+                        float(self._parameter("membrane_size_y")),
+                        float(self._parameter("membrane_size_z")),
+                    ]
+                ),
                 self._parameter("membrane_particle_radius"),
-                self._parameter("box_size")
+                self._parameter("box_size"),
             )
             self.actin_util.add_repulsions_with_actin(
                 all_membrane_particle_types(),
                 self._parameter("membrane_particle_radius"),
                 ActinUtil.DEFAULT_FORCE_CONSTANT,
                 self.system,
-                util
+                util,
             )
 
     def add_reactions(self):
@@ -365,18 +376,22 @@ class ActinSimulation:
         n = 0
         while f"obstacle{n}_position_x" in self.parameters:
             self.simulation.add_topology(
-                "Obstacle", 
-                ["obstacle"], 
-                np.array([[
-                    float(self._parameter(f"obstacle{n}_position_x")),
-                    float(self._parameter(f"obstacle{n}_position_y")),
-                    float(self._parameter(f"obstacle{n}_position_z")),
-                ]])
+                "Obstacle",
+                ["obstacle"],
+                np.array(
+                    [
+                        [
+                            float(self._parameter(f"obstacle{n}_position_x")),
+                            float(self._parameter(f"obstacle{n}_position_y")),
+                            float(self._parameter(f"obstacle{n}_position_z")),
+                        ]
+                    ]
+                ),
             )
             n += 1
         if n > 0:
             print(f"Added {n} obstacle(s).")
-            
+
     def add_membrane(self):
         """
         Add membrane types and particles.
@@ -386,18 +401,22 @@ class ActinSimulation:
         ReaddyUtil.add_monomers_from_data(
             self.simulation,
             get_membrane_monomers(
-                np.array([
-                    float(self._parameter("membrane_center_x")),
-                    float(self._parameter("membrane_center_y")),
-                    float(self._parameter("membrane_center_z")),
-                ]), 
-                np.array([
-                    float(self._parameter("membrane_size_x")),
-                    float(self._parameter("membrane_size_y")),
-                    float(self._parameter("membrane_size_z")),
-                ]), 
+                np.array(
+                    [
+                        float(self._parameter("membrane_center_x")),
+                        float(self._parameter("membrane_center_y")),
+                        float(self._parameter("membrane_center_z")),
+                    ]
+                ),
+                np.array(
+                    [
+                        float(self._parameter("membrane_size_x")),
+                        float(self._parameter("membrane_size_y")),
+                        float(self._parameter("membrane_size_z")),
+                    ]
+                ),
                 self._parameter("membrane_particle_radius"),
-            )
+            ),
         )
 
     def add_crystal_structure_monomers(self):

--- a/simularium_readdy_models/actin/actin_util.py
+++ b/simularium_readdy_models/actin/actin_util.py
@@ -144,7 +144,6 @@ class ActinUtil:
         "add_membrane": False,
         "add_obstacles": False,
         "actin_constraints": True,
-        "add_monomer_box_potentials": False,
         "add_extra_box": False,
         "barbed_binding_site": False,
         "binding_site_reaction_distance": 0.1,
@@ -3131,8 +3130,6 @@ class ActinUtil:
         """
         Confine free monomers to boxes centered at center with extent.
         """
-        if not bool(parameters["add_monomer_box_potentials"]):
-            return
         particle_types = {
             "actin": ["actin#free", "actin#free_ATP"],
             "arp": ["arp2#free"],

--- a/simularium_readdy_models/actin/actin_util.py
+++ b/simularium_readdy_models/actin/actin_util.py
@@ -717,7 +717,7 @@ class ActinUtil:
                 longitudinal_bonds=longitudinal_bonds,
             )
             print(f"monomers:{monomers}")
-            ActinUtil.add_monomers_from_data(simulation, monomers)
+            ReaddyUtil.add_monomers_from_data(simulation, monomers)
 
     @staticmethod
     def add_fibers_from_data(
@@ -736,56 +736,7 @@ class ActinUtil:
             use_uuids=use_uuids,
             longitudinal_bonds=longitudinal_bonds,
         )
-        ActinUtil.add_monomers_from_data(simulation, fiber_monomers)
-
-    @staticmethod
-    def add_monomers_from_data(simulation, monomer_data):
-        """
-        add actin and other monomers.
-
-        monomer_data : {
-            "topologies": {
-                "[topology ID]" : {
-                    "type_name": "[topology type]",
-                    "particle_ids": []
-                },
-            "particles": {
-                "[particle ID]" : {
-                    "type_name": "[particle type]",
-                    "position": np.zeros(3),
-                    "neighbor_ids": [],
-                },
-            },
-        }
-        * IDs are uuid strings or ints
-        """
-        topologies = []
-        for topology_id in monomer_data["topologies"]:
-            topology = monomer_data["topologies"][topology_id]
-            types = []
-            positions = []
-            for particle_id in topology["particle_ids"]:
-                particle = monomer_data["particles"][particle_id]
-                types.append(particle["type_name"])
-                positions.append(particle["position"])
-            top = simulation.add_topology(
-                topology["type_name"], types, np.array(positions)
-            )
-            added_edges = []
-            for index, particle_id in enumerate(topology["particle_ids"]):
-                for neighbor_id in monomer_data["particles"][particle_id][
-                    "neighbor_ids"
-                ]:
-                    neighbor_index = topology["particle_ids"].index(neighbor_id)
-                    if (index, neighbor_index) not in added_edges and (
-                        neighbor_index,
-                        index,
-                    ) not in added_edges:
-                        top.get_graph().add_edge(index, neighbor_index)
-                        added_edges.append((index, neighbor_index))
-                        added_edges.append((neighbor_index, index))
-            topologies.append(top)
-        return topologies
+        ReaddyUtil.add_monomers_from_data(simulation, fiber_monomers)
 
     @staticmethod
     def add_actin_dimer(position, simulation):

--- a/simularium_readdy_models/actin/actin_util.py
+++ b/simularium_readdy_models/actin/actin_util.py
@@ -34,7 +34,13 @@ pointed_monomer_positions = []
 
 
 obstacle_time_index = 0
-obstacle_position = np.array([41., 0, 0]) # TODO set from another simulator etc
+obstacle_controlled_position = np.array([0., 0., 0.]) # can be set from another simulator etc
+
+
+def set_obstacle_controlled_position(pos):
+    global obstacle_controlled_position
+    obstacle_controlled_position = pos
+    return pos
 
 
 class ActinUtil:
@@ -50,6 +56,13 @@ class ActinUtil:
         set_parameters(parameters)
         if displacements is not None:
             set_displacements(displacements)
+        set_obstacle_controlled_position(
+            np.array([
+                float(parameters["obstacle_controlled_position_x"]),
+                float(parameters["obstacle_controlled_position_y"]),
+                float(parameters["obstacle_controlled_position_z"]),
+            ])
+        )
 
     DEFAULT_PARAMETERS = {
         "name": "actin",
@@ -66,6 +79,7 @@ class ActinUtil:
         "seed_n_fibers": 0,
         "seed_fiber_length": 0.0,
         "orthogonal_seed": False,
+        "orthogonal_seed_length": 50.0,  # nm
         "branched_seed": False,
         "only_linear_actin_constraints": False,
         "reactions": True,
@@ -105,6 +119,9 @@ class ActinUtil:
         "obstacle_diff_coeff": 0.0,
         "use_box_obstacle": False,
         "position_obstacle_stride": 0,
+        "obstacle_controlled_position_x": 0.0,
+        "obstacle_controlled_position_y": 0.0,
+        "obstacle_controlled_position_z": 0.0,
         "n_fixed_monomers_pointed": 0,
         "n_fixed_monomers_barbed": 0,
         "displace_pointed_end_tangent": False,
@@ -1494,7 +1511,7 @@ class ActinUtil:
         if parameters["verbose"]:
             print("Translate obstacle")
         v = topology.graph.get_vertices()[0] # there should only be one particle in topology
-        recipe.change_particle_position(v, obstacle_position)
+        recipe.change_particle_position(v, obstacle_controlled_position)
         obstacle_time_index += 1
         return recipe
 

--- a/simularium_readdy_models/actin/actin_util.py
+++ b/simularium_readdy_models/actin/actin_util.py
@@ -34,7 +34,9 @@ pointed_monomer_positions = []
 
 
 obstacle_time_index = 0
-obstacle_controlled_position = np.array([0., 0., 0.]) # can be set from another simulator etc
+obstacle_controlled_position = np.array(
+    [0.0, 0.0, 0.0]
+)  # can be set from another simulator etc
 
 
 def set_obstacle_controlled_position(pos):
@@ -57,11 +59,13 @@ class ActinUtil:
         if displacements is not None:
             set_displacements(displacements)
         set_obstacle_controlled_position(
-            np.array([
-                float(parameters["obstacle_controlled_position_x"]),
-                float(parameters["obstacle_controlled_position_y"]),
-                float(parameters["obstacle_controlled_position_z"]),
-            ])
+            np.array(
+                [
+                    float(parameters["obstacle_controlled_position_x"]),
+                    float(parameters["obstacle_controlled_position_y"]),
+                    float(parameters["obstacle_controlled_position_z"]),
+                ]
+            )
         )
 
     DEFAULT_PARAMETERS = {
@@ -170,7 +174,10 @@ class ActinUtil:
         Get the barbed end binding site vertex.
         """
         results = ReaddyUtil.get_vertices_of_type(
-            topology, "binding_site", exact_match=False, error_msg="Failed to find binding site vertex"
+            topology,
+            "binding_site",
+            exact_match=False,
+            error_msg="Failed to find binding site vertex",
         )
         if len(results) > 1:
             raise Exception(
@@ -427,9 +434,7 @@ class ActinUtil:
         )
         at_branch = False
         direction = -1 if barbed else 1
-        vertices.append(
-            ActinUtil.get_next_actin(topology, v_new, direction, False)
-        )
+        vertices.append(ActinUtil.get_next_actin(topology, v_new, direction, False))
         if vertices[0] is None:
             (
                 vertices,
@@ -1504,12 +1509,17 @@ class ActinUtil:
         """
         global obstacle_time_index
         recipe = readdy.StructuralReactionRecipe(topology)
-        if obstacle_time_index > 0 and obstacle_time_index % parameters["position_obstacle_stride"] != 0:
+        if (
+            obstacle_time_index > 0
+            and obstacle_time_index % parameters["position_obstacle_stride"] != 0
+        ):
             obstacle_time_index += 1
             return recipe
         if parameters["verbose"]:
             print("Translate obstacle")
-        v = topology.graph.get_vertices()[0] # there should only be one particle in topology
+        v = topology.graph.get_vertices()[
+            0
+        ]  # there should only be one particle in topology
         recipe.change_particle_position(v, obstacle_controlled_position)
         obstacle_time_index += 1
         return recipe
@@ -1856,7 +1866,7 @@ class ActinUtil:
             system,
             n_polymer_numbers,
         )
-        util.add_bond( 
+        util.add_bond(
             [
                 "actin#branch_1",
                 "actin#branch_ATP_1",
@@ -3076,7 +3086,9 @@ class ActinUtil:
         )
 
     @staticmethod
-    def add_repulsions_with_actin(other_types, other_radius, force_constant, system, util):
+    def add_repulsions_with_actin(
+        other_types, other_radius, force_constant, system, util
+    ):
         """
         Add repulsions between actin etc types and a given list of types.
         """
@@ -3371,7 +3383,11 @@ class ActinUtil:
         """
         for i in ActinUtil.polymer_number_range():
             if parameters["barbed_binding_site"]:
-                bs_number = str(ReaddyUtil.calculate_polymer_number(i, 1, ActinUtil.n_polymer_numbers()))
+                bs_number = str(
+                    ReaddyUtil.calculate_polymer_number(
+                        i, 1, ActinUtil.n_polymer_numbers()
+                    )
+                )
                 system.topologies.add_spatial_reaction(
                     f"Barbed_Growth_BS{i}: Actin-Polymer(binding_site#{i}) + "
                     "Actin-Monomer-ATP(actin#free_ATP) -> "
@@ -3385,28 +3401,32 @@ class ActinUtil:
                     "Actin-Monomer-ATP(actin#free_ATP) -> "
                     f"Actin-Polymer#GrowingBarbed(actin#ATP_{i}--actin#new_ATP)",
                     rate=parameters["barbed_growth_ATP_rate"],
-                    radius=2 * parameters["actin_radius"] + parameters["reaction_distance"],
+                    radius=2 * parameters["actin_radius"]
+                    + parameters["reaction_distance"],
                 )
                 system.topologies.add_spatial_reaction(
                     f"Barbed_Growth_ATP1{i}: Actin-Polymer(actin#barbed_{i}) + "
                     "Actin-Monomer-ATP(actin#free_ATP) -> "
                     f"Actin-Polymer#GrowingBarbed(actin#{i}--actin#new_ATP)",
                     rate=parameters["barbed_growth_ATP_rate"],
-                    radius=2 * parameters["actin_radius"] + parameters["reaction_distance"],
+                    radius=2 * parameters["actin_radius"]
+                    + parameters["reaction_distance"],
                 )
                 system.topologies.add_spatial_reaction(
                     f"Barbed_Growth_ADP1{i}: Actin-Polymer(actin#barbed_{i}) + "
                     "Actin-Monomer(actin#free) -> "
                     f"Actin-Polymer#GrowingBarbed(actin#{i}--actin#new)",
                     rate=parameters["barbed_growth_ADP_rate"],
-                    radius=2 * parameters["actin_radius"] + parameters["reaction_distance"],
+                    radius=2 * parameters["actin_radius"]
+                    + parameters["reaction_distance"],
                 )
                 system.topologies.add_spatial_reaction(
                     f"Barbed_Growth_ADP2{i}: Actin-Polymer(actin#barbed_ATP_{i}) + "
                     "Actin-Monomer(actin#free) -> "
                     f"Actin-Polymer#GrowingBarbed(actin#ATP_{i}--actin#new)",
                     rate=parameters["barbed_growth_ADP_rate"],
-                    radius=2 * parameters["actin_radius"] + parameters["reaction_distance"],
+                    radius=2 * parameters["actin_radius"]
+                    + parameters["reaction_distance"],
                 )
         system.topologies.add_spatial_reaction(
             "Branch_Barbed_Growth_ATP1: Actin-Polymer(actin#branch_barbed_1) + "

--- a/simularium_readdy_models/common/__init__.py
+++ b/simularium_readdy_models/common/__init__.py
@@ -6,6 +6,6 @@ from .repeated_timer import RepeatedTimer  # noqa: F401
 from .membrane_util import (
     add_membrane_particle_types, 
     add_membrane_constraints, 
-    init_membrane, 
+    get_membrane_monomers, 
     all_membrane_particle_types
 )  # noqa: F401

--- a/simularium_readdy_models/common/__init__.py
+++ b/simularium_readdy_models/common/__init__.py
@@ -4,8 +4,8 @@ from .particle_data import ParticleData  # noqa: F401
 from .readdy_util import ReaddyUtil  # noqa: F401
 from .repeated_timer import RepeatedTimer  # noqa: F401
 from .membrane_util import (
-    add_membrane_particle_types, 
-    add_membrane_constraints, 
-    get_membrane_monomers, 
-    all_membrane_particle_types
+    add_membrane_particle_types,
+    add_membrane_constraints,
+    get_membrane_monomers,
+    all_membrane_particle_types,
 )  # noqa: F401

--- a/simularium_readdy_models/common/membrane_util.py
+++ b/simularium_readdy_models/common/membrane_util.py
@@ -40,9 +40,11 @@ def add_membrane_particle_types(system, particle_radius, temperature_K, viscosit
     particle_types = all_membrane_particle_types()
     for t in particle_types:
         system.add_topology_species(t, diffCoeff)
-        
-        
-def _add_weak_interaction(types1, types2, force_const, bond_length, depth, cutoff, system):
+
+
+def _add_weak_interaction(
+    types1, types2, force_const, bond_length, depth, cutoff, system
+):
     """
     Adds a weak interaction piecewise harmonic bond to the system
         from each type in types1
@@ -70,8 +72,8 @@ def _add_box_potential(particle_types, origin, extent, force_constant, system):
             origin=origin,
             extent=extent,
         )
-    
-    
+
+
 def _calculate_lattice(size, particle_radius):
     """
     Calculate the x and y lattice coordinates of the membrane
@@ -89,15 +91,15 @@ def _calculate_lattice(size, particle_radius):
     if plane_dim < 0 or width[1] < float_info.epsilon:
         raise Exception("The membrane size must be zero in one and only one dimension.")
     result = [
-        np.arange(0, width[0], 2. * particle_radius), 
-        np.arange(0, width[1], 2. * particle_radius * np.sqrt(3))
+        np.arange(0, width[0], 2.0 * particle_radius),
+        np.arange(0, width[1], 2.0 * particle_radius * np.sqrt(3)),
     ]
     return result, plane_dim
-        
-        
+
+
 def _calculate_box_potentials(center, size, particle_radius, box_size):
     """
-    Get the origin and extent for each of the four box potentials 
+    Get the origin and extent for each of the four box potentials
     constraining the edges of the membrane.
     """
     coords, plane_dim = _calculate_lattice(size, particle_radius)
@@ -142,67 +144,89 @@ def add_membrane_constraints(system, center, size, particle_radius, box_size):
     outer_types = _leaflet_types("outer")
     # weak interaction between particles in the same leaflet
     _add_weak_interaction(
-        inner_types, 
-        inner_types, 
-        force_const=250., bond_length=2. * particle_radius, 
-        depth=7., cutoff=2.5 * 2. * particle_radius, system=system
+        inner_types,
+        inner_types,
+        force_const=250.0,
+        bond_length=2.0 * particle_radius,
+        depth=7.0,
+        cutoff=2.5 * 2.0 * particle_radius,
+        system=system,
     )
     _add_weak_interaction(
-        outer_types, 
-        outer_types, 
-        force_const=250., bond_length=2. * particle_radius, 
-        depth=7., cutoff=2.5 * 2. * particle_radius, system=system
+        outer_types,
+        outer_types,
+        force_const=250.0,
+        bond_length=2.0 * particle_radius,
+        depth=7.0,
+        cutoff=2.5 * 2.0 * particle_radius,
+        system=system,
     )
     # (very weak) bond to pass ReaDDy requirement in order to define edges
     util.add_bond(
-        inner_types, 
-        inner_types, 
-        force_const=1e-10, bond_length=2. * particle_radius, system=system
+        inner_types,
+        inner_types,
+        force_const=1e-10,
+        bond_length=2.0 * particle_radius,
+        system=system,
     )
     util.add_bond(
-        outer_types, 
-        outer_types, 
-        force_const=1e-10, bond_length=2. * particle_radius, system=system
+        outer_types,
+        outer_types,
+        force_const=1e-10,
+        bond_length=2.0 * particle_radius,
+        system=system,
     )
     # bonds between pairs of inner and outer particles
     util.add_bond(
-        inner_types, 
-        outer_types, 
-        force_const=250., bond_length=2. * particle_radius, system=system
+        inner_types,
+        outer_types,
+        force_const=250.0,
+        bond_length=2.0 * particle_radius,
+        system=system,
     )
     # angles between inner-outer pairs and their neighbors on the sheet
     util.add_angle(
-        inner_types, 
-        outer_types, 
-        outer_types, 
-        force_const=1000., angle=0.5 * np.pi, system=system
+        inner_types,
+        outer_types,
+        outer_types,
+        force_const=1000.0,
+        angle=0.5 * np.pi,
+        system=system,
     )
     util.add_angle(
-        inner_types, 
-        inner_types, 
-        outer_types, 
-        force_const=1000., angle=0.5 * np.pi, system=system
+        inner_types,
+        inner_types,
+        outer_types,
+        force_const=1000.0,
+        angle=0.5 * np.pi,
+        system=system,
     )
     # box potentials for edges
-    box_origins, box_extents = _calculate_box_potentials(center, size, particle_radius, box_size)
+    box_origins, box_extents = _calculate_box_potentials(
+        center, size, particle_radius, box_size
+    )
     corner_suffixes = ["4_1", "2_3"]
     for n in range(1, 5):
         box_types = [f"membrane#outer_edge_{n}", f"membrane#inner_edge_{n}"]
         for suffix in corner_suffixes:
             if f"{n}" in suffix:
-                box_types += [f"membrane#outer_edge_{suffix}", f"membrane#inner_edge_{suffix}"]
+                box_types += [
+                    f"membrane#outer_edge_{suffix}",
+                    f"membrane#inner_edge_{suffix}",
+                ]
                 break
         _add_box_potential(
-            box_types, 
-            origin=box_origins[n - 1], 
-            extent=box_extents[n - 1], 
-            force_constant=250., system=system
+            box_types,
+            origin=box_origins[n - 1],
+            extent=box_extents[n - 1],
+            force_constant=250.0,
+            system=system,
         )
 
 
 def get_membrane_monomers(center, size, particle_radius, start_particle_id=0, top_id=0):
     """
-    get all the monomer data for the membrane patch 
+    get all the monomer data for the membrane patch
     defined by center size and particle radius.
     """
     coords, plane_dim = _calculate_lattice(size, particle_radius)
@@ -213,67 +237,67 @@ def get_membrane_monomers(center, size, particle_radius, start_particle_id=0, to
     types = np.array(2 * n_lattice_points * ["membrane#side-_init_0_0"])
     lattice_dim = 0
     for dim in range(3):
-        
+
         if dim == plane_dim:
             positions[:n_lattice_points, dim] = center[dim] + particle_radius
             positions[n_lattice_points:, dim] = center[dim] - particle_radius
             continue
-        
+
         values = coords[lattice_dim] - 0.5 * size[dim] + center[dim]
         offset = particle_radius * (1 if lattice_dim < 1 else np.sqrt(3))
-        
+
         # positions and types
         for i in range(rows):
-            
+
             p = values if lattice_dim < 1 else values[i]
-            
+
             start_ix = 2 * i * cols
-            positions[start_ix:start_ix + cols, dim] = p
+            positions[start_ix : start_ix + cols, dim] = p
             if i < 1:
                 types[start_ix] = "membrane#outer_edge_4_1"
-                types[start_ix + 1:start_ix + cols] = "membrane#outer_edge_1"
+                types[start_ix + 1 : start_ix + cols] = "membrane#outer_edge_1"
             else:
                 types[start_ix] = "membrane#outer_edge_4"
-                types[start_ix + 1:start_ix + cols] = "membrane#outer"
-                
+                types[start_ix + 1 : start_ix + cols] = "membrane#outer"
+
             start_ix += n_lattice_points
-            positions[start_ix:start_ix + cols, dim] = p
+            positions[start_ix : start_ix + cols, dim] = p
             if i < 1:
                 types[start_ix] = "membrane#inner_edge_4_1"
-                types[start_ix + 1:start_ix + cols] = "membrane#inner_edge_1"
+                types[start_ix + 1 : start_ix + cols] = "membrane#inner_edge_1"
             else:
                 types[start_ix] = "membrane#inner_edge_4"
-                types[start_ix + 1:start_ix + cols] = "membrane#inner"
-            
+                types[start_ix + 1 : start_ix + cols] = "membrane#inner"
+
             start_ix = (2 * i + 1) * cols
-            positions[start_ix:start_ix + cols, dim] = p + offset
+            positions[start_ix : start_ix + cols, dim] = p + offset
             if i < rows - 1:
-                types[start_ix:start_ix + cols - 1] = "membrane#outer"
+                types[start_ix : start_ix + cols - 1] = "membrane#outer"
                 types[start_ix + cols - 1] = "membrane#outer_edge_2"
             else:
-                types[start_ix:start_ix + cols - 1] = "membrane#outer_edge_3"
+                types[start_ix : start_ix + cols - 1] = "membrane#outer_edge_3"
                 types[start_ix + cols - 1] = "membrane#outer_edge_2_3"
-            
+
             start_ix += n_lattice_points
-            positions[start_ix:start_ix + cols, dim] = p + offset
+            positions[start_ix : start_ix + cols, dim] = p + offset
             if i < rows - 1:
-                types[start_ix:start_ix + cols - 1] = "membrane#inner"
+                types[start_ix : start_ix + cols - 1] = "membrane#inner"
                 types[start_ix + cols - 1] = "membrane#inner_edge_2"
             else:
-                types[start_ix:start_ix + cols - 1] = "membrane#inner_edge_3"
+                types[start_ix : start_ix + cols - 1] = "membrane#inner_edge_3"
                 types[start_ix + cols - 1] = "membrane#inner_edge_2_3"
-            
+
         lattice_dim += 1
 
     particles = {}
     for p in range(2 * n_lattice_points):
         particles[p + start_particle_id] = ParticleData(
-                unique_id=p,
-                type_name=types[p],
-                position=positions[p],
-                neighbor_ids=[],
-            )
-    
+            unique_id=p,
+            type_name=types[p],
+            position=positions[p],
+            neighbor_ids=[],
+        )
+
     # edges
     for ix in range(n_lattice_points):
         p_ix = ix + start_particle_id
@@ -312,15 +336,15 @@ def get_membrane_monomers(center, size, particle_radius, start_particle_id=0, to
 
     result = {
         "topologies": {
-            top_id : {
+            top_id: {
                 "type_name": "Membrane",
-                "particle_ids": (np.arange(2 * n_lattice_points) + start_particle_id).tolist(),
+                "particle_ids": (
+                    np.arange(2 * n_lattice_points) + start_particle_id
+                ).tolist(),
             }
         },
         "particles": {},
     }
-    particles = {
-        p_id: dict(particle_data) for p_id, particle_data in particles.items()
-    }
+    particles = {p_id: dict(particle_data) for p_id, particle_data in particles.items()}
     result["particles"] = particles
     return result

--- a/simularium_readdy_models/common/membrane_util.py
+++ b/simularium_readdy_models/common/membrane_util.py
@@ -287,16 +287,28 @@ def get_membrane_monomers(center, size, particle_radius, start_particle_id, top_
             particles[other_ix + 1].neighbor_ids.append(other_ix)
         if math.ceil((ix + 1) / cols) >= 2 * rows:
             continue
-        if (ix % (2 * cols) != (2 * cols) - 1):
-            particles[p_ix].neighbor_ids.append(p_ix + cols)
-            particles[p_ix + cols].neighbor_ids.append(p_ix)
-            particles[other_ix].neighbor_ids.append(other_ix + cols)
-            particles[other_ix + cols].neighbor_ids.append(other_ix)
-        if (ix % (2 * cols) != 0):
-            particles[p_ix].neighbor_ids.append(p_ix + cols - 1)
-            particles[p_ix + cols - 1].neighbor_ids.append(p_ix)
-            particles[other_ix].neighbor_ids.append(other_ix + cols - 1)
-            particles[other_ix + cols - 1].neighbor_ids.append(other_ix)
+        if ix % (2 * cols) != 2 * cols - 1:
+            if ix % (2 * cols) < cols:
+                particles[p_ix].neighbor_ids.append(p_ix + cols)
+                particles[p_ix + cols].neighbor_ids.append(p_ix)
+                particles[other_ix].neighbor_ids.append(other_ix + cols)
+                particles[other_ix + cols].neighbor_ids.append(other_ix)
+            else:
+                particles[p_ix].neighbor_ids.append(p_ix + cols + 1)
+                particles[p_ix + cols + 1].neighbor_ids.append(p_ix)
+                particles[other_ix].neighbor_ids.append(other_ix + cols + 1)
+                particles[other_ix + cols + 1].neighbor_ids.append(other_ix)
+        if ix % (2 * cols) != cols - 1:
+            if ix % (2 * cols) < cols - 1:
+                particles[p_ix + 1].neighbor_ids.append(p_ix + cols)
+                particles[p_ix + cols].neighbor_ids.append(p_ix + 1)
+                particles[other_ix + 1].neighbor_ids.append(other_ix + cols)
+                particles[other_ix + cols].neighbor_ids.append(other_ix + 1)
+            else:
+                particles[p_ix].neighbor_ids.append(p_ix + cols)
+                particles[p_ix + cols].neighbor_ids.append(p_ix)
+                particles[other_ix].neighbor_ids.append(other_ix + cols)
+                particles[other_ix + cols].neighbor_ids.append(other_ix)
 
     result = {
         "topologies": {

--- a/simularium_readdy_models/common/membrane_util.py
+++ b/simularium_readdy_models/common/membrane_util.py
@@ -200,7 +200,7 @@ def add_membrane_constraints(system, center, size, particle_radius, box_size):
         )
 
 
-def get_membrane_monomers(center, size, particle_radius, start_particle_id, top_id):
+def get_membrane_monomers(center, size, particle_radius, start_particle_id=0, top_id=0):
     """
     get all the monomer data for the membrane patch 
     defined by center size and particle radius.

--- a/simularium_readdy_models/common/membrane_util.py
+++ b/simularium_readdy_models/common/membrane_util.py
@@ -200,7 +200,7 @@ def add_membrane_constraints(system, center, size, particle_radius, box_size):
         )
 
 
-def get_membrane_monomers(center, size, particle_radius):
+def get_membrane_monomers(center, size, particle_radius, start_particle_id, top_id):
     """
     get all the monomer data for the membrane patch 
     defined by center size and particle radius.
@@ -267,7 +267,7 @@ def get_membrane_monomers(center, size, particle_radius):
 
     particles = {}
     for p in range(2 * n_lattice_points):
-        particles[p] = ParticleData(
+        particles[p + start_particle_id] = ParticleData(
                 unique_id=p,
                 type_name=types[p],
                 position=positions[p],
@@ -276,32 +276,33 @@ def get_membrane_monomers(center, size, particle_radius):
     
     # edges
     for ix in range(n_lattice_points):
-        other_ix = ix + n_lattice_points
-        particles[ix].neighbor_ids.append(other_ix)
-        particles[other_ix].neighbor_ids.append(ix)
-        if n % cols != cols - 1:
-            particles[ix].neighbor_ids.append(ix + 1)
-            particles[ix + 1].neighbor_ids.append(ix)
+        p_ix = ix + start_particle_id
+        other_ix = ix + n_lattice_points + start_particle_id
+        particles[p_ix].neighbor_ids.append(other_ix)
+        particles[other_ix].neighbor_ids.append(p_ix)
+        if ix % cols != cols - 1:
+            particles[p_ix].neighbor_ids.append(p_ix + 1)
+            particles[p_ix + 1].neighbor_ids.append(p_ix)
             particles[other_ix].neighbor_ids.append(other_ix + 1)
             particles[other_ix + 1].neighbor_ids.append(other_ix)
-        if math.ceil((n + 1) / cols) >= 2 * rows:
+        if math.ceil((ix + 1) / cols) >= 2 * rows:
             continue
-        if (n % (2 * cols) != (2 * cols) - 1):
-            particles[ix].neighbor_ids.append(ix + cols)
-            particles[ix + cols].neighbor_ids.append(ix)
+        if (ix % (2 * cols) != (2 * cols) - 1):
+            particles[p_ix].neighbor_ids.append(p_ix + cols)
+            particles[p_ix + cols].neighbor_ids.append(p_ix)
             particles[other_ix].neighbor_ids.append(other_ix + cols)
             particles[other_ix + cols].neighbor_ids.append(other_ix)
-        if (n % (2 * cols) != 0):
-            particles[ix].neighbor_ids.append(ix + cols - 1)
-            particles[ix + cols - 1].neighbor_ids.append(ix)
+        if (ix % (2 * cols) != 0):
+            particles[p_ix].neighbor_ids.append(p_ix + cols - 1)
+            particles[p_ix + cols - 1].neighbor_ids.append(p_ix)
             particles[other_ix].neighbor_ids.append(other_ix + cols - 1)
             particles[other_ix + cols - 1].neighbor_ids.append(other_ix)
 
     result = {
         "topologies": {
-            2 * n_lattice_points + 1 : {
+            top_id : {
                 "type_name": "Membrane",
-                "particle_ids": (np.arange(2 * n_lattice_points)).tolist(),
+                "particle_ids": (np.arange(2 * n_lattice_points) + start_particle_id).tolist(),
             }
         },
         "particles": {},

--- a/simularium_readdy_models/common/readdy_util.py
+++ b/simularium_readdy_models/common/readdy_util.py
@@ -1454,7 +1454,6 @@ class ReaddyUtil:
         else:
             return np.array([float(input_size)] * 3)
 
-
     @staticmethod
     def add_monomers_from_data(simulation, monomer_data):
         """

--- a/simularium_readdy_models/common/readdy_util.py
+++ b/simularium_readdy_models/common/readdy_util.py
@@ -1050,7 +1050,7 @@ class ReaddyUtil:
         return simulation
 
     @staticmethod
-    def get_current_particle_edges(current_topologies):
+    def get_current_particle_edges(current_topologies, id_difference=0):
         """
         During a running simulation,
         get all the edges in the ReaDDy topologies
@@ -1060,19 +1060,19 @@ class ReaddyUtil:
         result = []
         for top in current_topologies:
             for v1, v2 in top.graph.edges:
-                p1_id = top.particle_id_of_vertex(v1)
-                p2_id = top.particle_id_of_vertex(v2)
+                p1_id = top.particle_id_of_vertex(v1) - id_difference
+                p2_id = top.particle_id_of_vertex(v2) - id_difference
                 if p1_id <= p2_id:
                     result.append((p1_id, p2_id))
         return result
 
     @staticmethod
-    def get_current_monomers(current_topologies):
+    def get_current_monomers(current_topologies, id_difference=0):
         """
         During a running simulation,
         get data for topologies of particles.
         """
-        edges = ReaddyUtil.get_current_particle_edges(current_topologies)
+        edges = ReaddyUtil.get_current_particle_edges(current_topologies, id_difference)
         result = {
             "topologies": {},
             "particles": {},
@@ -1080,14 +1080,15 @@ class ReaddyUtil:
         for index, topology in enumerate(current_topologies):
             particle_ids = []
             for p in topology.particles:
-                particle_ids.append(p.id)
+                pid = p.id - id_difference
+                particle_ids.append(pid)
                 neighbor_ids = []
                 for edge in edges:
-                    if p.id == edge[0]:
+                    if pid == edge[0]:
                         neighbor_ids.append(edge[1])
-                    elif p.id == edge[1]:
+                    elif pid == edge[1]:
                         neighbor_ids.append(edge[0])
-                result["particles"][p.id] = {
+                result["particles"][pid] = {
                     "type_name": p.type,
                     "position": p.pos,
                     "neighbor_ids": neighbor_ids,

--- a/simularium_readdy_models/visualization/actin_visualization.py
+++ b/simularium_readdy_models/visualization/actin_visualization.py
@@ -21,7 +21,7 @@ class ActinVisualization:
     """
     visualize an actin trajectory in Simularium.
     """
-    
+
     @staticmethod
     def _display_data() -> dict[str, DisplayData]:
         """
@@ -256,7 +256,9 @@ class ActinVisualization:
         )
         time_inc = int(converter._data.agent_data.times.shape[0] / n_timepoints)
         if time_inc >= 2:
-            converter._data = converter.filter_data([EveryNthTimestepFilter(n=time_inc)])
+            converter._data = converter.filter_data(
+                [EveryNthTimestepFilter(n=time_inc)]
+            )
         converter.save(output_path=path_to_readdy_h5, validate_ids=False)
 
 


### PR DESCRIPTION
Adds features to actin ReaDDy model in order to polymerize actin against a membrane to recapitulate and test the brownian ratchet model.

Membrane can be represented as:
- box potential that excludes actin monomers
- large particle that can either be fixed or diffusing and can have its position set at a given stride
- bilayer of coarse grained particles

A binding site particle can be added to the barbed end of actin filaments to increase spatial accuracy of binding.